### PR TITLE
CI: update dist on ubuntu-latest

### DIFF
--- a/.github/workflows/update_dist.yml
+++ b/.github/workflows/update_dist.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   update-dist:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
macos-latest -> ubuntu-latest

TypeScriptのコンパイルはmacosである必要はないため。