### PR TITLE
Add *.xcstrings to default mtime targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ this action will store these file's mtime attributes:
 * `**/*.xib`
 * `**/*.storyboard`
 * `**/*.strings`
+* `**/*.xcstrings`
 * `**/*.plist`
 * `**/*.intentdefinition`
 * `**/*.json`

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: ''
   use-default-mtime-targets:
-    description: 'process default mtime targets: **/*.swift , **/*.xib , **/*.storyboard , **/*.strings , **/*.plist , **/*.xcassets , **/*.xcassets/**/* , **/*.bundle , **/*.bundle/**/*, **/*.xcdatamodel , **/*.xcdatamodel/**/* , **/*.framework , **/*.framework/**/* , **/*.xcframework , **/*.xcframework/**/* , **/*.m , **/*.mm , **/*.h , **/*.c , **/*.cc , **/*.cpp , **/*.hpp , **/*.hxx'
+    description: 'process default mtime targets: **/*.swift , **/*.xib , **/*.storyboard , **/*.strings , **/*.xcstrings, **/*.plist , **/*.xcassets , **/*.xcassets/**/* , **/*.bundle , **/*.bundle/**/*, **/*.xcdatamodel , **/*.xcdatamodel/**/* , **/*.framework , **/*.framework/**/* , **/*.xcframework , **/*.xcframework/**/* , **/*.m , **/*.mm , **/*.h , **/*.c , **/*.cc , **/*.cpp , **/*.hpp , **/*.hxx'
     required: false
     default: 'true'
   delete-used-deriveddata-cache:

--- a/src/post.ts
+++ b/src/post.ts
@@ -227,6 +227,7 @@ async function storeMtime(
     "**/*.xib",
     "**/*.storyboard",
     "**/*.strings",
+    "**/*.xcstrings",
     "**/*.plist",
     "**/*.intentdefinition",
     "**/*.json",


### PR DESCRIPTION
Support Xcode15 String Catalogs.

https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog